### PR TITLE
Fix duplicate identifier names

### DIFF
--- a/src/gen/swiftCodeGen.ts
+++ b/src/gen/swiftCodeGen.ts
@@ -1,4 +1,5 @@
 import { convertType } from "../utils/typeMap";
+import { ensureUniqueNames } from "./uniqueNameChecker";
 
 const now = new Date();
 const dateTime = now.toISOString().replace('T', ' ').split('.')[0];
@@ -93,28 +94,30 @@ function generateJsStringProperty(variables: string[], functions: any[]): string
 }
 
 export function generateSwiftCode(variables: string[], functions: any[], enums: any[], typeAliases: any[], packageInfo: any) {
+  const { uniqueVariables, uniqueFunctions, uniqueEnums, uniqueTypeAliases } = ensureUniqueNames(variables, functions, enums, typeAliases);
+
   let swiftCode = generateHeader(packageInfo);
 
   swiftCode += `/// An enumeration of TypeScript identifiers generated to be used in Swift code.\n`
   swiftCode += `enum TypeSwift {\n`;
 
-  if (variables.length > 0) {
-    swiftCode += generateVariableCases(variables);
+  if (uniqueVariables.length > 0) {
+    swiftCode += generateVariableCases(uniqueVariables);
   }
 
-  if (functions.length > 0) {
-    swiftCode += generateFunctionCases(functions);
+  if (uniqueFunctions.length > 0) {
+    swiftCode += generateFunctionCases(uniqueFunctions);
   }
 
-  if (enums.length > 0) {
-    swiftCode += generateEnumCases(enums);
+  if (uniqueEnums.length > 0) {
+    swiftCode += generateEnumCases(uniqueEnums);
   }
 
-  if (typeAliases.length > 0) {
-    swiftCode += generateTypeAliasCases(typeAliases);
+  if (uniqueTypeAliases.length > 0) {
+    swiftCode += generateTypeAliasCases(uniqueTypeAliases);
   }
 
-  swiftCode += generateJsStringProperty(variables, functions);
+  swiftCode += generateJsStringProperty(uniqueVariables, uniqueFunctions);
 
   swiftCode += `}\n`;
   return swiftCode;

--- a/src/gen/uniqueNameChecker.ts
+++ b/src/gen/uniqueNameChecker.ts
@@ -1,0 +1,52 @@
+export function ensureUniqueNames(
+  variables: string[],
+  functions: any[],
+  enums: any[],
+  typeAliases: any[]
+) {
+  const nameSet = new Set<string>();
+  const uniqueVariables = variables.filter(variable => {
+    if (nameSet.has(variable)) {
+      return false;
+    } else {
+      nameSet.add(variable);
+      return true;
+    }
+  });
+
+  const uniqueEnums = enums.filter(enumDecl => {
+    if (nameSet.has(enumDecl.name)) {
+      return false;
+    } else {
+      nameSet.add(enumDecl.name);
+      return true;
+    }
+  });
+
+  const uniqueTypeAliases = typeAliases.filter(alias => {
+    if (nameSet.has(alias.name)) {
+      return false;
+    } else {
+      nameSet.add(alias.name);
+      return true;
+    }
+  });
+
+  const uniqueFunctions = functions.reduce((acc: any[], func: any) => {
+    const funcSignature = `${func.name}(${func.parameters.map((param: any) => param.type).join(', ')})`;
+    if (!acc.some(existingFunc => {
+      const existingSignature = `${existingFunc.name}(${existingFunc.parameters.map((param: any) => param.type).join(', ')})`;
+      return existingSignature === funcSignature;
+    })) {
+      acc.push(func);
+    }
+    return acc;
+  }, []);
+
+  return {
+    uniqueVariables,
+    uniqueFunctions,
+    uniqueEnums,
+    uniqueTypeAliases
+  };
+}

--- a/src/swiftgen.ts
+++ b/src/swiftgen.ts
@@ -13,7 +13,6 @@ export function runSwiftGen(config: any) {
 
   const packageJsonPath = path.join(__dirname, '..', 'package.json');
   const packageInfo = readJsonFile(packageJsonPath);
-  console.log("Loaded package info:", packageInfo);
 
   function initializeProject(filePath: string) {
     const project = new Project();

--- a/src/utils/addShebang.ts
+++ b/src/utils/addShebang.ts
@@ -9,5 +9,3 @@ const fileContent = fs.readFileSync(filePath, 'utf8');
 
 // Prepend the shebang line
 fs.writeFileSync(filePath, shebang + fileContent);
-
-console.log(`Added shebang to ${filePath}`);


### PR DESCRIPTION
Disallow duplicate:

- variables
- enums
- type aliases

For functions, allow duplicate names if:

- no duplicate parameters

This includes void functions.