### PR TITLE
fix: string parameter formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "swiftgen",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "swiftgen",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "commander": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swiftgen",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Generate typesafe Swift code using input TypeScript code.",
   "main": "dist/index.js",
   "bin": {

--- a/src/gen/swiftCodeGen.ts
+++ b/src/gen/swiftCodeGen.ts
@@ -78,7 +78,11 @@ function generateJsStringProperty(variables: string[], functions: any[]): string
   });
 
   functions.forEach(func => {
-    const paramNames = func.parameters.map((param: any) => `\\(${param.name})`).join(', ');
+    const paramNames = func.parameters.map((param: any) => {
+      const wrappedParam = param.type === 'String' ? `'\\(${param.name})'` : `\\(${param.name})`;
+      return wrappedParam;
+    }).join(', ');
+
     if (func.parameters.length > 0) {
       code += `    case .${func.name}(${func.parameters.map((param: any) => `let ${param.name}`).join(', ')}):\n`;
       code += `      return "${func.name}(${paramNames})"\n`;


### PR DESCRIPTION
Fix issue with `String` parameters not being properly formatted for `jsString` generation.

### Before Fix

```swift
enum TypeSwift {
  
  var jsString: String {
    switch self {
    case .setInputText(let text): return "setInputText(\(text))"
    // ..
}
```

### After Fix

```swift
enum TypeSwift {
  
  var jsString: String {
    switch self {
    case .setInputText(let text): return "setInputText('\(text)')"
    // ..
}
```